### PR TITLE
Caching for browserified resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 plugins
 =======
+
+Changes in 2.2.9
+--------------
+
+Browserify plugins can now cache generated files.
+The file will be parsed and generated once, and then cached version will be returned for subsequent requests.
+  
+        "browserify": {
+          "module": "mixdown-plugins#Browserify",
+          "options": {
+            "cache": true,
+            "compress": false,

--- a/lib/browserify.js
+++ b/lib/browserify.js
@@ -14,7 +14,9 @@ Browserify.prototype.attach = function(options) {
         // ignoreList = _.map(options.ignore, function(str) { 
         //     return new RegExp(str.replace('.js', '') + '(\.js)?$');
         // });
-
+    var cacheEnabled = options.cache; 
+    var cache = {};
+  
     this.browserify = function(entry, callback) {
 
         if (!_.isFunction(callback)) {
@@ -33,17 +35,22 @@ Browserify.prototype.attach = function(options) {
             b.require(source, { expose: dest });
         });
         
-        b.bundle(function(err, bundleScript) {
-            if (!err && options.compress) {
+        if (cacheEnabled && cache[entry]) {
+          callback(null, cache[entry]);
+        } else {
+          b.bundle(function (err, bundleScript) {
+              if (!err && options.compress) {
                 try {
-                    bundleScript = UglifyJS.minify(bundleScript, { fromString: true }).code;
+                  bundleScript = UglifyJS.minify(bundleScript, { fromString: true }).code;
                 }
                 catch (e) {
-                    err = e;
+                  err = e;
                 }
-            }
-            callback(err, bundleScript);
-        });
+              }
+              if (cacheEnabled) cache[entry] = bundleScript;
+              callback(err, bundleScript);
+          })          
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixdown-plugins",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "main": "index",
   "description": "General use plugins for mixdown.",
   "keywords": [


### PR DESCRIPTION
Browserified files are re-generated at each request. In our case it blocks node from processing requests for more than 4 seconds. This fix allows to enable caching for browserified files.
